### PR TITLE
Refactor is_json Function for Cleaner Code

### DIFF
--- a/models/llama3_1/api/tool_utils.py
+++ b/models/llama3_1/api/tool_utils.py
@@ -24,7 +24,6 @@ def is_json(s):
         return isinstance(parsed, dict)
     except json.JSONDecodeError:
         return False
-    return True
 
 
 class ToolUtils:
@@ -96,3 +95,4 @@ class ToolUtils:
             fname = t.tool_name
             args = json.dumps(t.arguments)
             return f"<function={fname}>{args}</function>"
+


### PR DESCRIPTION
This small yet impactful change refactors the is_json function to eliminate a redundant return statement, enhancing code readability and maintaining core functionality.